### PR TITLE
Allow fastq path in metadata - 15.10.22

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -2,7 +2,7 @@ metadata: config/samples.tsv
 units: config/units.tsv
 
 # Dataset name
-dataset: 'Test-TravisCI'
+dataset: 'Test-GithubActionsCI'
 
 fastq: 
       table: config/fastq.tsv
@@ -29,7 +29,7 @@ ref:
         "resources/Gene2TranscriptMap.tsv"
 
 # Chromosome names for the appropriate species. Should correspond to the reference fasta/gff files. 
-chroms: ['X']
+contigs: ['X']
 
 # List of contrasts to do DE and Fst analysis on. Should correspond to the 'treatment' columns of the samples.tsv file, and be separated by an underscore "_". i.e ['control_case'], or ['Kisumu_Tiassale'].
 # The treatment names themselves must not contain underscores

--- a/config/exampleconfig.yaml
+++ b/config/exampleconfig.yaml
@@ -4,14 +4,13 @@ metadata: config/samples.tsv                    # samplesheet metadata file
 
 dataset: 'Ag_Bouake'                            # Dataset name: Can be anything, will be used to name some main output files
 
-## Fastq filenames and locations can either be specified in the config/fastq.tsv file. 
-## OR if auto: True -
+## Fastq filenames and locations can either be specified in the config/samples.tsv file in columns called
+## fq1 and fq2 (paired end reads) OR if auto: True -
 ## gzipped fastq files should be stored in the resources/reads/ directory
 ## If the sample name is Kisumu1 in the samples.tsv file, the paired-end reads 
 ## should be named Kisumu1_1.fastq.gz, and Kisumu1_2.fastq.gz. 
 ## Treatment names in samples.tsv should not contain underscores
-fastq: 
-      table: #config/fastq.tsv
+fastq:
       auto: True                                                              # set auto if your files follow the above rules
 
 cutadapt:
@@ -68,11 +67,7 @@ DifferentialExpression:
 
 VariantAnalysis:
       activate: True
-<<<<<<< HEAD
       caller: 'freebayes'
-=======
-      caller: 'freebayes'                 # or 'octopus' but requires octopus local install
->>>>>>> 44ebad588c0d2ece20af419dc7fea203b835e2a8
       ploidy: 10                          # Ploidy level for freebayes to call at (Generally we are using pooled samples).For diploid organisms, this should be 2 * number of individuals in each pool
       chunks: 9                           # Number of chunks to split each chromosome into when parallelising freebayes. 9 or less is recommended. 
 

--- a/config/exampleconfig.yaml
+++ b/config/exampleconfig.yaml
@@ -22,7 +22,7 @@ cutadapt:
 # Currently, the variant calling and analysis part of workflow requires genes mapped to chromosomes and their physical location.
 # Please ensure that these correspond exactly to the reference fasta/gff files. Extra unwanted chromosomes (unplaced contigs) can be ignored. 
 # if you need to remove a prefix (Such as "AgamP4_"or "AaegL5_") from a file, use this sed command - i.e - "sed s/AgamP4_// An.gambiae.fasta > An.gambiae_clean.fasta"
-chroms: ['2L', '2R', '3L', '3R', 'X']
+contigs: ['2L', '2R', '3L', '3R', 'X']
 
 # Paths for reference files 
 ref:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -135,7 +135,7 @@ def GetDesiredOutputs(wildcards):
     #                 [
     #                     "results/variantAnalysis/vcfs/octopus/variant.{contig}.vcf"
     #                 ]
-    #                 contig=chroms,
+    #                 contig=contigs,
     #         )
     #     elif config['VariantAnalyis']['caller'] == 'freebayes':
     #         wanted_input.extend(
@@ -160,7 +160,7 @@ def GetDesiredOutputs(wildcards):
                     "results/variantAnalysis/diversity/DxyPerGene.tsv",
                     "results/variantAnalysis/selection/fst/Fst.{comp}.{wsize}.{contig}.svg",
                 ],
-                contig=config["chroms"],
+                contig=config["contigs"],
                 dataset=config["dataset"],
                 comp=config["contrasts"],
                 wsize=config["VariantAnalysis"]["selection"]["pbs"]["windownames"],
@@ -175,7 +175,7 @@ def GetDesiredOutputs(wildcards):
                         "results/variantAnalysis/selection/TajimasDPerGene.tsv",
                         "results/variantAnalysis/selection/fst/Fst.{comp}.{wsize}.{contig}.svg",
                     ],
-                    contig=config["chroms"],
+                    contig=config["contigs"],
                     comp=config["contrasts"],
                     wsize=config["VariantAnalysis"]["selection"]["pbs"]["windownames"],
                 )
@@ -190,7 +190,7 @@ def GetDesiredOutputs(wildcards):
                     "results/variantAnalysis/ancestry/n_AIMS_per_chrom.tsv",
                     "results/variantAnalysis/ancestry/AIM_fraction_{contig}.tsv",
                 ],
-                contig=config["chroms"],
+                contig=config["contigs"],
             )
         )
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -57,9 +57,9 @@ def getFASTQs(wildcards, rules=None):
 
 def getVCF(wildcards):
     if config["VariantAnalysis"]["caller"] == "octopus":
-        return "results/variantAnalysis/vcfs/octopus/variants.{chrom}.vcf"
+        return "results/variantAnalysis/vcfs/octopus/variants.{contig}.vcf"
     elif config["VariantAnalysis"]["caller"] == "freebayes":
-        return "results/variantAnalysis/vcfs/freebayes/variants.{chrom}.vcf"
+        return "results/variantAnalysis/vcfs/freebayes/variants.{contig}.vcf"
     else:
         assert config["VariantAnalysis"]["caller"] in [
             "octopus",
@@ -88,7 +88,6 @@ def GetDesiredOutputs(wildcards):
                 ],
                 sample=samples,
                 n=[1, 2],
-                chrom=config["chroms"],
             )
         )
         if config["VariantAnalysis"]["activate"]:
@@ -134,14 +133,14 @@ def GetDesiredOutputs(wildcards):
     #         wanted_input.extend(
     #             expand
     #                 [
-    #                     "results/variantAnalysis/vcfs/octopus/variant.{chrom}.vcf"
+    #                     "results/variantAnalysis/vcfs/octopus/variant.{contig}.vcf"
     #                 ]
-    #                 chrom=chroms,
+    #                 contig=chroms,
     #         )
     #     elif config['VariantAnalyis']['caller'] == 'freebayes':
     #         wanted_input.extend(
     #                 [
-    #                     "results/variantAnalysis/vcfs/freebayes/variant.{chrom}.vcf"
+    #                     "results/variantAnalysis/vcfs/freebayes/variant.{contig}.vcf"
     #                 ]
     #         )
 
@@ -149,19 +148,19 @@ def GetDesiredOutputs(wildcards):
         wanted_input.extend(
             expand(
                 [
-                    "results/variantAnalysis/vcfs/stats/{chrom}.txt",
-                    "results/variantAnalysis/pca/PCA-{chrom}-{dataset}.svg",
+                    "results/variantAnalysis/vcfs/stats/{contig}.txt",
+                    "results/variantAnalysis/pca/PCA-{contig}-{dataset}.svg",
                     "results/variantAnalysis/SNPstats/snpsPerGenomicFeature.tsv",
                     "results/variantAnalysis/SNPstats/nSNPsPerGene.tsv",
-                    "results/variantAnalysis/diversity/{dataset}_SNPdensity_{chrom}.svg",
+                    "results/variantAnalysis/diversity/{dataset}_SNPdensity_{contig}.svg",
                     "results/variantAnalysis/diversity/SequenceDiversity.tsv",
                     "results/variantAnalysis/selection/FstPerGene.tsv",
                     "results/variantAnalysis/selection/TajimasDPerGene.tsv",
                     "results/variantAnalysis/diversity/SequenceDivPerGene.tsv",
                     "results/variantAnalysis/diversity/DxyPerGene.tsv",
-                    "results/variantAnalysis/selection/fst/Fst.{comp}.{wsize}.{chrom}.svg",
+                    "results/variantAnalysis/selection/fst/Fst.{comp}.{wsize}.{contig}.svg",
                 ],
-                chrom=config["chroms"],
+                contig=config["chroms"],
                 dataset=config["dataset"],
                 comp=config["contrasts"],
                 wsize=config["VariantAnalysis"]["selection"]["pbs"]["windownames"],
@@ -174,9 +173,9 @@ def GetDesiredOutputs(wildcards):
                     [
                         "results/variantAnalysis/selection/FstPerGene.tsv",
                         "results/variantAnalysis/selection/TajimasDPerGene.tsv",
-                        "results/variantAnalysis/selection/fst/Fst.{comp}.{wsize}.{chrom}.svg",
+                        "results/variantAnalysis/selection/fst/Fst.{comp}.{wsize}.{contig}.svg",
                     ],
-                    chrom=config["chroms"],
+                    contig=config["chroms"],
                     comp=config["contrasts"],
                     wsize=config["VariantAnalysis"]["selection"]["pbs"]["windownames"],
                 )
@@ -189,9 +188,9 @@ def GetDesiredOutputs(wildcards):
                     "results/variantAnalysis/ancestry/AIMs_summary.tsv",
                     "results/variantAnalysis/ancestry/AIM_fraction_whole_genome.svg",
                     "results/variantAnalysis/ancestry/n_AIMS_per_chrom.tsv",
-                    "results/variantAnalysis/ancestry/AIM_fraction_{chrom}.tsv",
+                    "results/variantAnalysis/ancestry/AIM_fraction_{contig}.tsv",
                 ],
-                chrom=config["chroms"],
+                contig=config["chroms"],
             )
         )
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -13,11 +13,12 @@ def getFASTQs(wildcards, rules=None):
     If there are more than one wildcard (aka, sample), only return one fastq file
     If the rule is HISAT2align, then return the fastqs with -1 and -2 flags
     """
+    metadata = pd.read_csv(config["metadata"], sep="\t")
+
     if config["cutadapt"]["activate"] == True:
         if rules in ["KallistoQuant", "HISAT2align", "HISAT2align_input"]:
-            units = pd.read_csv(config["metadata"], sep="\t")
-            units = (
-                units.assign(
+            metadata = (
+                metadata.assign(
                     fq1=f"resources/reads/trimmed/" + units["sampleID"] + "_1.fastq.gz"
                 )
                 .assign(
@@ -25,24 +26,21 @@ def getFASTQs(wildcards, rules=None):
                 )
                 .set_index("sampleID")
             )
-            u = units.loc[wildcards.sample, ["fq1", "fq2"]].dropna()
+            u = metadata.loc[wildcards.sample, ["fq1", "fq2"]].dropna()
             if rules == "HISAT2align":
                 return [f"-1 {u.fq1} -2 {u.fq2}"]
             else:
                 return [f"{u.fq1}", f"{u.fq2}"]
 
     if config["fastq"]["auto"]:
-        units = pd.read_csv(config["metadata"], sep="\t")
-        units = (
-            units.assign(fq1=f"resources/reads/" + units["sampleID"] + "_1.fastq.gz")
-            .assign(fq2=f"resources/reads/" + units["sampleID"] + "_2.fastq.gz")
+        metadata = (
+            metadata.assign(fq1=f"resources/reads/" + metadata["sampleID"] + "_1.fastq.gz")
+            .assign(fq2=f"resources/reads/" + metadata["sampleID"] + "_2.fastq.gz")
             .set_index("sampleID")
         )
     else:
-        assert os.path.isfile(
-            config["fastq"]["table"]
-        ), f"config['fastq']['table'] (the config/fastq.tsv file) does not seem to exist. Please create one, or use the 'auto' option and name the fastq files as specified in the config/README.md"
-        units = pd.read_csv(config["fastq"]["table"], sep="\t", index_col="sampleID")
+        assert 'fq1' in metadata.columns, f"The fq1 column in the metadata does not seem to exist. Please create one, or use the 'auto' option and name the fastq files as specified in the config/README.md"
+        assert 'fq2' in metadata.columns, f"The fq2 column in the metadata does not seem to exist. Please create one, or use the 'auto' option and name the fastq files as specified in the config/README.md"
 
     if len(wildcards) > 1:
         u = units.loc[wildcards.sample, f"fq{wildcards.n}"]

--- a/workflow/rules/filterAnnotate.smk
+++ b/workflow/rules/filterAnnotate.smk
@@ -109,15 +109,15 @@ rule ExtractBedVCF:
     input:
         vcf=expand(
             "results/variantAnalysis/vcfs/annot.missense.{contig}.vcf",
-            contig=config["chroms"],
+            contig=config["contigs"],
         ),
     output:
-        bed=expand("resources/regions/missense.pos.{contig}.bed", contig=config["chroms"]),
+        bed=expand("resources/regions/missense.pos.{contig}.bed", contig=config["contigs"]),
     conda:
         "../envs/pythonGenomics.yaml"
     log:
         "logs/ExtractBedVCF.log",
     params:
-        chroms=config["chroms"],
+        contigs=config["contigs"],
     script:
         "../scripts/ExtractBedVCF.py"

--- a/workflow/rules/filterAnnotate.smk
+++ b/workflow/rules/filterAnnotate.smk
@@ -7,13 +7,13 @@ rule ConcatVCFs:
     """
     input:
         calls=expand(
-            "results/variantAnalysis/vcfs/freebayes/{{chrom}}/variants.{i}.vcf",
+            "results/variantAnalysis/vcfs/freebayes/{{contig}}/variants.{i}.vcf",
             i=chunks,
         ),
     output:
-        temp("results/variantAnalysis/vcfs/freebayes/variants.{chrom}.vcf"),
+        temp("results/variantAnalysis/vcfs/freebayes/variants.{contig}.vcf"),
     log:
-        "logs/ConcatVCFs/{chrom}.log",
+        "logs/ConcatVCFs/{contig}.log",
     conda:
         "../envs/variants.yaml"
     threads: 4
@@ -28,9 +28,9 @@ rule RestrictToSNPs:
     input:
         getVCF,
     output:
-        temp("results/variantAnalysis/vcfs/variants.{chrom}.vcf"),
+        temp("results/variantAnalysis/vcfs/variants.{contig}.vcf"),
     log:
-        "logs/bcftoolsView/{chrom}.log",
+        "logs/bcftoolsView/{contig}.log",
     params:
         extra="-v snps",
     wrapper:
@@ -59,16 +59,16 @@ rule snpEff:
     Run snpEff on the VCFs 
     """
     input:
-        calls="results/variantAnalysis/vcfs/variants.{chrom}.vcf",
+        calls="results/variantAnalysis/vcfs/variants.{contig}.vcf",
         dl="workflow/scripts/snpEff/db.dl",
     output:
         calls=expand(
-            "results/variantAnalysis/vcfs/{dataset}.{{chrom}}.vcf.gz",
+            "results/variantAnalysis/vcfs/{dataset}.{{contig}}.vcf.gz",
             dataset=config["dataset"],
         ),
-        csvStats="results/variantAnalysis/vcfs/snpEff.summary.{chrom}.csv",
+        csvStats="results/variantAnalysis/vcfs/snpEff.summary.{contig}.csv",
     log:
-        "logs/snpEff/snpEff.{chrom}.log",
+        "logs/snpEff/snpEff.{contig}.log",
     conda:
         "../envs/snpeff.yaml"
     params:
@@ -87,11 +87,11 @@ rule MissenseAndQualFilter:
     Filter VCFs for missense variants and quality (used later for diffsnps analysis)
     """
     input:
-        vcf="results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz",
+        vcf="results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
     output:
-        "results/variantAnalysis/vcfs/annot.missense.{chrom}.vcf",
+        "results/variantAnalysis/vcfs/annot.missense.{contig}.vcf",
     log:
-        "logs/snpSift/missense_vcf_{chrom}.log",
+        "logs/snpSift/missense_vcf_{contig}.log",
     conda:
         "../envs/snpeff.yaml"
     params:
@@ -108,11 +108,11 @@ rule ExtractBedVCF:
     """
     input:
         vcf=expand(
-            "results/variantAnalysis/vcfs/annot.missense.{chrom}.vcf",
-            chrom=config["chroms"],
+            "results/variantAnalysis/vcfs/annot.missense.{contig}.vcf",
+            contig=config["chroms"],
         ),
     output:
-        bed=expand("resources/regions/missense.pos.{chrom}.bed", chrom=config["chroms"]),
+        bed=expand("resources/regions/missense.pos.{contig}.bed", contig=config["chroms"]),
     conda:
         "../envs/pythonGenomics.yaml"
     log:

--- a/workflow/rules/misc.smk
+++ b/workflow/rules/misc.smk
@@ -4,14 +4,14 @@ rule AlleleTables:
     """
     input:
         bam="results/alignments/{sample}.bam",
-        bed="resources/regions/missense.pos.{chrom}.bed",
+        bed="resources/regions/missense.pos.{contig}.bed",
         ref=config["ref"]["genome"],
     output:
-        "results/variantAnalysis/alleleTables/{sample}.chr{chrom}.allele.table",
+        "results/variantAnalysis/alleleTables/{sample}.chr{contig}.allele.table",
     conda:
         "../envs/variants.yaml"
     log:
-        "logs/AlleleTables/{sample}.{chrom}.log",
+        "logs/AlleleTables/{sample}.{contig}.log",
     params:
         basedir=workflow.basedir,
         ignore_indels="false",
@@ -34,9 +34,9 @@ rule DifferentialSNPs:
         gff=config["ref"]["gff"],
         geneNames=config["ref"]["genes2transcripts"],
         tables=expand(
-            "results/variantAnalysis/alleleTables/{sample}.chr{chrom}.allele.table",
+            "results/variantAnalysis/alleleTables/{sample}.chr{contig}.allele.table",
             sample=samples,
-            chrom=config["chroms"],
+            contig=config["chroms"],
         ),
     output:
         expand(

--- a/workflow/rules/misc.smk
+++ b/workflow/rules/misc.smk
@@ -36,7 +36,7 @@ rule DifferentialSNPs:
         tables=expand(
             "results/variantAnalysis/alleleTables/{sample}.chr{contig}.allele.table",
             sample=samples,
-            contig=config["chroms"],
+            contig=config["contigs"],
         ),
     output:
         expand(
@@ -57,7 +57,7 @@ rule DifferentialSNPs:
         "logs/DifferentialSNPs.log",
     params:
         DEcontrasts=config["contrasts"],
-        chroms=config["chroms"],
+        contigs=config["contigs"],
         mincounts=100,
         pval_flt=0.001,  # pvalues already adjusted but way want extra filter for sig file
     script:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -11,7 +11,7 @@ rule CheckInputs:
         touch("results/.input.check"),
     params:
         metadata=config["metadata"],
-        chroms=config["chroms"],
+        contigs=config["contigs"],
         gffpath=config["ref"]["gff"],
         gene_names=config["ref"]["genes2transcripts"],
         contrasts=config["contrasts"],
@@ -145,7 +145,7 @@ rule multiQC:
     input:
         expand("resources/reads/qc/{sample}_{n}_fastqc.zip", sample=samples, n=[1, 2]),
         expand(
-            "results/variantAnalysis/vcfs/stats/{contig}.txt", contig=config["chroms"]
+            "results/variantAnalysis/vcfs/stats/{contig}.txt", contig=config["contigs"]
         )
         if config["VariantAnalysis"]["activate"]
         else [],

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -53,7 +53,7 @@ rule cutAdapt:
         qc="resources/trimmed/{sample}.qc.txt",
     params:
         # https://cutadapt.readthedocs.io/en/stable/guide.html#adapter-types
-        adapters="-a AGAGCACACGTCTGAACTCCAGTCAC -g AGATCGGAAGAGCACACGT -A AGAGCACACGTCTGAACTCCAGTCAC -G AGATCGGAAGAGCACACGT",
+        adapters=config['cutadapt']['adaptors']            #"-a AGAGCACACGTCTGAACTCCAGTCAC -g AGATCGGAAGAGCACACGT -A AGAGCACACGTCTGAACTCCAGTCAC -G AGATCGGAAGAGCACACGT",
         # https://cutadapt.readthedocs.io/en/stable/guide.html#
         extra="--minimum-length 1 -q 20",
     log:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -105,15 +105,15 @@ rule vcfStats:
     """
     input:
         vcf=expand(
-            "results/variantAnalysis/vcfs/{dataset}.{{chrom}}.vcf.gz",
+            "results/variantAnalysis/vcfs/{dataset}.{{contig}}.vcf.gz",
             dataset=config["dataset"],
         ),
     output:
-        vcfStats="results/variantAnalysis/vcfs/stats/{chrom}.txt",
+        vcfStats="results/variantAnalysis/vcfs/stats/{contig}.txt",
     conda:
         "../envs/variants.yaml"
     log:
-        "logs/vcfStats/{chrom}.log",
+        "logs/vcfStats/{contig}.log",
     shell:
         """
         bcftools stats {input} > {output} 2> {log}
@@ -145,7 +145,7 @@ rule multiQC:
     input:
         expand("resources/reads/qc/{sample}_{n}_fastqc.zip", sample=samples, n=[1, 2]),
         expand(
-            "results/variantAnalysis/vcfs/stats/{chrom}.txt", chrom=config["chroms"]
+            "results/variantAnalysis/vcfs/stats/{contig}.txt", contig=config["chroms"]
         )
         if config["VariantAnalysis"]["activate"]
         else [],

--- a/workflow/rules/variantAnalysis.smk
+++ b/workflow/rules/variantAnalysis.smk
@@ -9,8 +9,8 @@ rule SNPstatistics:
     """
     input:
         vcf=expand(
-            "results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz",
-            chrom=config["chroms"],
+            "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
+            contig=config["chroms"],
             dataset=config["dataset"],
         ),
         metadata=config["metadata"],
@@ -19,8 +19,8 @@ rule SNPstatistics:
         snpsPerGenomicFeature="results/variantAnalysis/SNPstats/snpsPerGenomicFeature.tsv",
         snpsPerGene="results/variantAnalysis/SNPstats/nSNPsPerGene.tsv",
         SNPdensityFig=expand(
-            "results/variantAnalysis/diversity/{dataset}_SNPdensity_{chrom}.svg",
-            chrom=config["chroms"],
+            "results/variantAnalysis/diversity/{dataset}_SNPdensity_{contig}.svg",
+            contig=config["chroms"],
             dataset=config["dataset"],
         ),
     log:
@@ -43,15 +43,15 @@ rule PCA:
     """
     input:
         vcf=expand(
-            "results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz",
-            chrom=config["chroms"],
+            "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
+            contig=config["chroms"],
             dataset=config["dataset"],
         ),
         metadata=config["metadata"],
     output:
         PCAfig=expand(
-            "results/variantAnalysis/pca/PCA-{chrom}-{dataset}.svg",
-            chrom=config["chroms"],
+            "results/variantAnalysis/pca/PCA-{contig}-{dataset}.svg",
+            contig=config["chroms"],
             dataset=config["dataset"],
         ),
     log:
@@ -74,8 +74,8 @@ rule SummaryStatistics:
     """
     input:
         vcf=expand(
-            "results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz",
-            chrom=config["chroms"],
+            "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
+            contig=config["chroms"],
             dataset=config["dataset"],
         ),
         metadata=config["metadata"],
@@ -106,22 +106,22 @@ rule WindowedFstPBS:
     input:
         metadata=config["metadata"],
         vcf=expand(
-            "results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz",
-            chrom=config["chroms"],
+            "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
+            contig=config["chroms"],
             dataset=config["dataset"],
         ),
     output:
         Fst=expand(
-            "results/variantAnalysis/selection/fst/Fst.{comp}.{wsize}.{chrom}.svg",
+            "results/variantAnalysis/selection/fst/Fst.{comp}.{wsize}.{contig}.svg",
             comp=config["contrasts"],
-            chrom=config["chroms"],
+            contig=config["chroms"],
             wsize=config["VariantAnalysis"]["selection"]["pbs"]["windownames"],
         ),
         PBS=(
             expand(
-                "results/variantAnalysis/selection/pbs/PBS.{pbscomp}.{wsize}.{chrom}.svg",
+                "results/variantAnalysis/selection/pbs/PBS.{pbscomp}.{wsize}.{contig}.svg",
                 pbscomp=config["VariantAnalysis"]["selection"]["pbs"]["contrasts"],
-                chrom=config["chroms"],
+                contig=config["chroms"],
                 wsize=config["VariantAnalysis"]["selection"]["pbs"]["windownames"],
             )
             if config["VariantAnalysis"]["selection"]["pbs"]["activate"]
@@ -156,8 +156,8 @@ rule PerGeneFstPBSDxyPi:
         gff=config["ref"]["gff"],
         geneNames=config["ref"]["genes2transcripts"],
         vcf=expand(
-            "results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz",
-            chrom=config["chroms"],
+            "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
+            contig=config["chroms"],
             dataset=config["dataset"],
         ),
     output:
@@ -189,8 +189,8 @@ rule AncestryInformativeMarkers:
     """
     input:
         vcf=expand(
-            "results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz",
-            chrom=config["chroms"],
+            "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
+            contig=config["chroms"],
             dataset=config["dataset"],
         ),
         metadata=config["metadata"],
@@ -201,8 +201,8 @@ rule AncestryInformativeMarkers:
         AIMs_fig="results/variantAnalysis/ancestry/AIM_fraction_whole_genome.svg",
         n_AIMs="results/variantAnalysis/ancestry/n_AIMS_per_chrom.tsv",
         AIMs_chroms=expand(
-            "results/variantAnalysis/ancestry/AIM_fraction_{chrom}.tsv",
-            chrom=config["chroms"],
+            "results/variantAnalysis/ancestry/AIM_fraction_{contig}.tsv",
+            contig=config["chroms"],
         ),
     log:
         "logs/AncestryInformativeMarkers.log",

--- a/workflow/rules/variantAnalysis.smk
+++ b/workflow/rules/variantAnalysis.smk
@@ -10,7 +10,7 @@ rule SNPstatistics:
     input:
         vcf=expand(
             "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
-            contig=config["chroms"],
+            contig=config["contigs"],
             dataset=config["dataset"],
         ),
         metadata=config["metadata"],
@@ -20,7 +20,7 @@ rule SNPstatistics:
         snpsPerGene="results/variantAnalysis/SNPstats/nSNPsPerGene.tsv",
         SNPdensityFig=expand(
             "results/variantAnalysis/diversity/{dataset}_SNPdensity_{contig}.svg",
-            contig=config["chroms"],
+            contig=config["contigs"],
             dataset=config["dataset"],
         ),
     log:
@@ -29,7 +29,7 @@ rule SNPstatistics:
         "../envs/pythonGenomics.yaml"
     params:
         dataset=config["dataset"],
-        chroms=config["chroms"],
+        contigs=config["contigs"],
         ploidy=config["VariantAnalysis"]["ploidy"],
         missingprop=config["VariantAnalysis"]["selection"]["missingness"],
         qualflt=30,
@@ -44,14 +44,14 @@ rule PCA:
     input:
         vcf=expand(
             "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
-            contig=config["chroms"],
+            contig=config["contigs"],
             dataset=config["dataset"],
         ),
         metadata=config["metadata"],
     output:
         PCAfig=expand(
             "results/variantAnalysis/pca/PCA-{contig}-{dataset}.svg",
-            contig=config["chroms"],
+            contig=config["contigs"],
             dataset=config["dataset"],
         ),
     log:
@@ -60,7 +60,7 @@ rule PCA:
         "../envs/pythonGenomics.yaml"
     params:
         dataset=config["dataset"],
-        chroms=config["chroms"],
+        contigs=config["contigs"],
         ploidy=config["VariantAnalysis"]["ploidy"],
         missingprop=config["VariantAnalysis"]["pca"]["missingness"],
         qualflt=30,
@@ -75,7 +75,7 @@ rule SummaryStatistics:
     input:
         vcf=expand(
             "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
-            contig=config["chroms"],
+            contig=config["contigs"],
             dataset=config["dataset"],
         ),
         metadata=config["metadata"],
@@ -91,7 +91,7 @@ rule SummaryStatistics:
         "../envs/pythonGenomics.yaml"
     params:
         dataset=config["dataset"],
-        chroms=config["chroms"],
+        contigs=config["contigs"],
         ploidy=config["VariantAnalysis"]["ploidy"],
         missingprop=config["VariantAnalysis"]["summaryStatistics"]["missingness"],
         qualflt=30,
@@ -107,21 +107,21 @@ rule WindowedFstPBS:
         metadata=config["metadata"],
         vcf=expand(
             "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
-            contig=config["chroms"],
+            contig=config["contigs"],
             dataset=config["dataset"],
         ),
     output:
         Fst=expand(
             "results/variantAnalysis/selection/fst/Fst.{comp}.{wsize}.{contig}.svg",
             comp=config["contrasts"],
-            contig=config["chroms"],
+            contig=config["contigs"],
             wsize=config["VariantAnalysis"]["selection"]["pbs"]["windownames"],
         ),
         PBS=(
             expand(
                 "results/variantAnalysis/selection/pbs/PBS.{pbscomp}.{wsize}.{contig}.svg",
                 pbscomp=config["VariantAnalysis"]["selection"]["pbs"]["contrasts"],
-                contig=config["chroms"],
+                contig=config["contigs"],
                 wsize=config["VariantAnalysis"]["selection"]["pbs"]["windownames"],
             )
             if config["VariantAnalysis"]["selection"]["pbs"]["activate"]
@@ -136,7 +136,7 @@ rule WindowedFstPBS:
         DEcontrasts=config["contrasts"],
         pbs=config["VariantAnalysis"]["selection"]["pbs"]["activate"],
         pbscomps=config["VariantAnalysis"]["selection"]["pbs"]["contrasts"],
-        chroms=config["chroms"],
+        contigs=config["contigs"],
         ploidy=config["VariantAnalysis"]["ploidy"],
         missingprop=config["VariantAnalysis"]["selection"]["missingness"],
         qualflt=30,
@@ -157,7 +157,7 @@ rule PerGeneFstPBSDxyPi:
         geneNames=config["ref"]["genes2transcripts"],
         vcf=expand(
             "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
-            contig=config["chroms"],
+            contig=config["contigs"],
             dataset=config["dataset"],
         ),
     output:
@@ -176,7 +176,7 @@ rule PerGeneFstPBSDxyPi:
         DEcontrasts=config["contrasts"],
         pbs=config["VariantAnalysis"]["selection"]["pbs"]["activate"],
         pbscomps=config["VariantAnalysis"]["selection"]["pbs"]["contrasts"],
-        chroms=config["chroms"],
+        contigs=config["contigs"],
         ploidy=config["VariantAnalysis"]["ploidy"],
         missingprop=config["VariantAnalysis"]["selection"]["missingness"],
     script:
@@ -190,7 +190,7 @@ rule AncestryInformativeMarkers:
     input:
         vcf=expand(
             "results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz",
-            contig=config["chroms"],
+            contig=config["contigs"],
             dataset=config["dataset"],
         ),
         metadata=config["metadata"],
@@ -202,7 +202,7 @@ rule AncestryInformativeMarkers:
         n_AIMs="results/variantAnalysis/ancestry/n_AIMS_per_chrom.tsv",
         AIMs_chroms=expand(
             "results/variantAnalysis/ancestry/AIM_fraction_{contig}.tsv",
-            contig=config["chroms"],
+            contig=config["contigs"],
         ),
     log:
         "logs/AncestryInformativeMarkers.log",
@@ -210,7 +210,7 @@ rule AncestryInformativeMarkers:
         "../envs/pythonGenomics.yaml"
     params:
         dataset=config["dataset"],
-        chroms=config["chroms"],
+        contigs=config["contigs"],
         ploidy=config["VariantAnalysis"]["ploidy"],
         missingprop=config["VariantAnalysis"]["ancestry"]["missingness"],
         qualflt=30,

--- a/workflow/rules/variantCalling.smk
+++ b/workflow/rules/variantCalling.smk
@@ -10,8 +10,8 @@ rule GenerateFreebayesParams:
         bamlist="results/alignments/bam.list",
         pops="results/alignments/populations.tsv",
         regions=expand(
-            "resources/regions/genome.{chrom}.region.{i}.bed",
-            chrom=config["chroms"],
+            "resources/regions/genome.{contig}.region.{i}.bed",
+            contig=config["chroms"],
             i=chunks,
         ),
     log:
@@ -36,11 +36,11 @@ rule VariantCallingFreebayes:
         ref=config["ref"]["genome"],
         samples="results/alignments/bam.list",
         pops="results/alignments/populations.tsv",
-        regions=ancient("resources/regions/genome.{chrom}.region.{i}.bed"),
+        regions=ancient("resources/regions/genome.{contig}.region.{i}.bed"),
     output:
-        temp("results/variantAnalysis/vcfs/freebayes/{chrom}/variants.{i}.vcf"),
+        temp("results/variantAnalysis/vcfs/freebayes/{contig}/variants.{i}.vcf"),
     log:
-        "logs/VariantCallingFreebayes/{chrom}.{i}.log",
+        "logs/VariantCallingFreebayes/{contig}.{i}.log",
     params:
         ploidy=config["VariantAnalysis"]["ploidy"],
     conda:
@@ -56,18 +56,18 @@ rule octopus:
         bam=expand("results/alignments/{sample}.bam", sample=samples),
         bai=expand("results/alignments/{sample}.bam.bai", sample=samples),
     output:
-        vcf=temp("results/variantAnalysis/vcfs/octopus/variants.{chrom}.vcf"),
-        vcf_index="results/variantAnalysis/vcfs/octopus/variants.{chrom}.vcf.tbi",
+        vcf=temp("results/variantAnalysis/vcfs/octopus/variants.{contig}.vcf"),
+        vcf_index="results/variantAnalysis/vcfs/octopus/variants.{contig}.vcf.tbi",
     params:
         ploidy=config["VariantAnalysis"]["ploidy"],
         err_model="PCRF.X10",
         forest="resources/forests/germline.v0.7.4.forest",
         max_coverage=1000,
     log:
-        "logs/octopus/{chrom}.log",
+        "logs/octopus/{contig}.log",
     threads: 16
     shell:
         """
-        octopus -R {input.reference} -I {input.bam} -T {wildcards.chrom} --organism-ploidy {params.ploidy} --downsample-above {params.max_coverage} \
+        octopus -R {input.reference} -I {input.bam} -T {wildcards.contig} --organism-ploidy {params.ploidy} --downsample-above {params.max_coverage} \
          --sequence-error-model {params.err_model} --forest {params.forest} -o {output} --threads {threads} 2> {log}
         """

--- a/workflow/rules/variantCalling.smk
+++ b/workflow/rules/variantCalling.smk
@@ -11,14 +11,14 @@ rule GenerateFreebayesParams:
         pops="results/alignments/populations.tsv",
         regions=expand(
             "resources/regions/genome.{contig}.region.{i}.bed",
-            contig=config["chroms"],
+            contig=config["contigs"],
             i=chunks,
         ),
     log:
         "logs/GenerateFreebayesParams.log",
     params:
         metadata=config["metadata"],
-        chroms=config["chroms"],
+        contigs=config["contigs"],
         chunks=config["VariantAnalysis"]["chunks"],
     conda:
         "../envs/diffexp.yaml"

--- a/workflow/scripts/Ag1000gSweepsDE.py
+++ b/workflow/scripts/Ag1000gSweepsDE.py
@@ -69,7 +69,7 @@ for comp in comparisons['contrast']:
             sweptgenes = np.array(cols['overlapping_DE_genes'].split(" "))
 
             if np.isin(sweptgenes, gene).any():
-                wheresweep[gene]['chrom'] = cols['chromosome']
+                wheresweep[gene]['contig'] = cols['chromosome']
                 wheresweep[gene]['epicenter'] = cols['epicenter']
                 wheresweep[gene]['known_loci'] = cols['known_loci']
 

--- a/workflow/scripts/AncestryInformativeMarkers.py
+++ b/workflow/scripts/AncestryInformativeMarkers.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 dataset = snakemake.params['dataset']
 metadata = pd.read_csv(snakemake.input['metadata'], sep="\t")
 metadata = metadata.sort_values(by='species').reset_index(drop=True)
-chroms = snakemake.params['chroms']
+contigs = snakemake.params['contigs']
 ploidy = snakemake.params['ploidy']
 numbers = rnaseqpop.get_numbers_dict(ploidy)
 qualflt = snakemake.params['qualflt']
@@ -34,7 +34,7 @@ all_gamb = defaultdict(list)
 all_colu = defaultdict(list)
 n_aims_per_chrom = {}
 
-for contig in chroms:
+for contig in contigs:
 
     # read in and filter data
     path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
@@ -181,7 +181,7 @@ if metadata['species'].isin(['arabiensis']).any():
     all_arab = defaultdict(list)
     n_aims_per_chrom = {}
 
-    for contig in chroms:
+    for contig in contigs:
 
         # read in and filter data
         path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"

--- a/workflow/scripts/AncestryInformativeMarkers.py
+++ b/workflow/scripts/AncestryInformativeMarkers.py
@@ -34,27 +34,27 @@ all_gamb = defaultdict(list)
 all_colu = defaultdict(list)
 n_aims_per_chrom = {}
 
-for chrom in chroms:
+for contig in chroms:
 
     # read in and filter data
-    path = f"results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz"
+    path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
     vcf, geno, acsubpops, pos, depth, snpeff, subpops, pops =  rnaseqpop.readAndFilterVcf(path=path,
-                                                               chrom=chrom,
+                                                               contig=contig,
                                                                samples=metadata,
                                                                numbers=numbers,
                                                                ploidy=ploidy,
                                                                qualflt=qualflt,
                                                                missingfltprop=missingprop)
-    aimspos = aims[chrom]['POS'][:]
+    aimspos = aims[contig]['POS'][:]
 
     # get intersection of aims and our SNPs
     aims_pos_mask, aims_mask_2 = pos.locate_intersection(aimspos)
     our_aims = pos[aims_pos_mask]
-    print(f"\n In the data, across all samples there are {our_aims.shape[0]} Ancestry Informative markers on Chromosome {chrom}")
+    print(f"\n In the data, across all samples there are {our_aims.shape[0]} Ancestry Informative markers on Chromosome {contig}")
 
     # get gamb and colu alleles, and subset to aims that we have in the rna-seq data 
-    aimscolu = aims[chrom]['colu_allele'][:][aims_mask_2]
-    aimsgamb = aims[chrom]['gamb_allele'][:][aims_mask_2]
+    aimscolu = aims[contig]['colu_allele'][:][aims_mask_2]
+    aimsgamb = aims[contig]['gamb_allele'][:][aims_mask_2]
 
     # get mask that was used in readAndFilterVcf()
     mask = pos.locate_intersection(vcf['variants/POS'])[1]
@@ -124,13 +124,13 @@ for chrom in chroms:
             n_aims_per_sample[sample] = dim-np.sum(np.isnan(arr))
             
     # store AIM fractions for each chromosome in outer dict 
-    aims_chrom_gamb[chrom] = dict(prop_gambiae)
-    aims_chrom_colu[chrom] = dict(prop_colu)
-    n_aims_per_chrom[chrom] = dict(n_aims_per_sample)
+    aims_chrom_gamb[contig] = dict(prop_gambiae)
+    aims_chrom_colu[contig] = dict(prop_colu)
+    n_aims_per_chrom[contig] = dict(n_aims_per_sample)
 
     # Store ancestry score per aim
-    ancestryPerAim[chrom] = pd.concat([pd.DataFrame(gambscores).add_suffix("_gamb"), pd.DataFrame(coluscores).add_suffix("_colu")], axis=1)
-    ancestryPerAim[chrom]['contig'] = chrom
+    ancestryPerAim[contig] = pd.concat([pd.DataFrame(gambscores).add_suffix("_gamb"), pd.DataFrame(coluscores).add_suffix("_colu")], axis=1)
+    ancestryPerAim[contig]['contig'] = contig
 
     # plot and store for each chromosome
     coludf = pd.DataFrame.from_dict(prop_colu, orient='index', columns=['AIM_fraction_coluzzii'])
@@ -138,8 +138,8 @@ for chrom in chroms:
     perchromdf = gambdf.merge(coludf, left_index=True, right_index=True)
     aimsperchromdf = pd.DataFrame.from_dict(n_aims_per_sample, orient='index', columns=['n_AIMs'])
 
-    perchromdf.to_csv(f"results/variantAnalysis/ancestry/AIM_fraction_{chrom}.tsv", sep="\t", index=True)
-    rnaseqpop.plot_aims(perchromdf, aimsperchromdf, species1="coluzzii", species2="gambiae", figtitle=f"AIM_fraction_{chrom}", total=False)
+    perchromdf.to_csv(f"results/variantAnalysis/ancestry/AIM_fraction_{contig}.tsv", sep="\t", index=True)
+    rnaseqpop.plot_aims(perchromdf, aimsperchromdf, species1="coluzzii", species2="gambiae", figtitle=f"AIM_fraction_{contig}", total=False)
 
 
 aims_chrom_gamb = rnaseqpop.flip_dict(aims_chrom_gamb)
@@ -181,26 +181,26 @@ if metadata['species'].isin(['arabiensis']).any():
     all_arab = defaultdict(list)
     n_aims_per_chrom = {}
 
-    for chrom in chroms:
+    for contig in chroms:
 
         # read in and filter data
-        path = f"results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz"
+        path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
         vcf, geno, acsubpops, pos, depth, snpeff, subpops, pops = rnaseqpop.readAndFilterVcf(path=path,
-                                                                chrom=chrom,
+                                                                contig=contig,
                                                                 samples=metadata,
                                                                 numbers=numbers,
                                                                 qualflt=qualflt,
                                                                 missingfltprop=missingprop)
-        aimspos = aims[chrom]['POS'][:]
+        aimspos = aims[contig]['POS'][:]
 
         # get intersection of aims and our SNPs
         aims_pos_mask, aims_mask_2 = pos.locate_intersection(aimspos)
         our_aims = pos[aims_pos_mask]
-        print(f"\n In the data, across all samples there are {our_aims.shape[0]} gamb-arab Ancestry Informative markers on Chromosome {chrom}")
+        print(f"\n In the data, across all samples there are {our_aims.shape[0]} gamb-arab Ancestry Informative markers on Chromosome {contig}")
 
         # get gamb and colu alleles, and subset to aims that we have in the rna-seq data 
-        aimsgamb = aims[chrom]['gambcolu_allele'][:][aims_mask_2]
-        aimsarab = aims[chrom]['arab_allele'][:][aims_mask_2]
+        aimsgamb = aims[contig]['gambcolu_allele'][:][aims_mask_2]
+        aimsarab = aims[contig]['arab_allele'][:][aims_mask_2]
 
         # get mask that was used in readAndFilterVcf()
         mask = pos.locate_intersection(vcf['variants/POS'])[1]
@@ -269,13 +269,13 @@ if metadata['species'].isin(['arabiensis']).any():
                 dim = arr.shape[0]
                 n_aims_per_sample[sample] = dim-np.sum(np.isnan(arr))
 
-        aims_chrom_gamb[chrom] = dict(prop_gambiae)
-        aims_chrom_arab[chrom] = dict(prop_arab)
-        n_aims_per_chrom[chrom] = dict(n_aims_per_sample)
+        aims_chrom_gamb[contig] = dict(prop_gambiae)
+        aims_chrom_arab[contig] = dict(prop_arab)
+        n_aims_per_chrom[contig] = dict(n_aims_per_sample)
 
         # Store ancestry score per aim
-        ancestryPerAim[chrom] = pd.concat([pd.DataFrame(gambscores).add_suffix("_gamb"), pd.DataFrame(coluscores).add_suffix("_colu")], axis=1)
-        ancestryPerAim[chrom]['contig'] = chrom
+        ancestryPerAim[contig] = pd.concat([pd.DataFrame(gambscores).add_suffix("_gamb"), pd.DataFrame(coluscores).add_suffix("_colu")], axis=1)
+        ancestryPerAim[contig]['contig'] = contig
 
         # plot and store for each chromosome
         gambdf = pd.DataFrame.from_dict(prop_gambiae, orient='index', columns=['AIM_fraction_gambiae'])
@@ -283,8 +283,8 @@ if metadata['species'].isin(['arabiensis']).any():
         perchromdf = gambdf.merge(arabdf, left_index=True, right_index=True)
         aimsperchromdf = pd.DataFrame.from_dict(n_aims_per_sample, orient='index', columns=['n_AIMs'])
 
-        perchromdf.to_csv(f"results/variantAnalysis/ancestry/AIM_fraction_{chrom}.arab.tsv", sep="\t", index=True)
-        rnaseqpop.plot_aims(perchromdf, aimsperchromdf, species1="arabiensis", species2="gambiae", figtitle=f"AIM_fraction_arab_{chrom}", total=False)
+        perchromdf.to_csv(f"results/variantAnalysis/ancestry/AIM_fraction_{contig}.arab.tsv", sep="\t", index=True)
+        rnaseqpop.plot_aims(perchromdf, aimsperchromdf, species1="arabiensis", species2="gambiae", figtitle=f"AIM_fraction_arab_{contig}", total=False)
 
     aims_chrom_gamb = rnaseqpop.flip_dict(aims_chrom_gamb)
     aims_chrom_arab = rnaseqpop.flip_dict(aims_chrom_arab)

--- a/workflow/scripts/DifferentialSNPs.R
+++ b/workflow/scripts/DifferentialSNPs.R
@@ -17,7 +17,7 @@ library(rtracklayer)
 
 
 ######## parse inputs #############
-chroms = snakemake@params[['chroms']]
+contigs = snakemake@params[['contigs']]
 metadata = fread(snakemake@input[['metadata']])
 contrasts = data.frame("contrast" = snakemake@params[['DEcontrasts']])
 comparisons = contrasts %>% separate(contrast, into = c("control", "case"), sep = "_")
@@ -52,7 +52,7 @@ for (i in 1:nrow(comparisons)){
   for (sample in samples){
     
     chrom_list = list()
-    for (contig in chroms){
+    for (contig in contigs){
       #read in data 
       alleles  = fread(glue("results/variantAnalysis/alleleTables/{sample}.chr{contig}.allele.table"))
       #sum lowercase and uppercase alleles, make new column (refcount)
@@ -64,7 +64,7 @@ for (i in 1:nrow(comparisons)){
                                     ref == 'A' ~ A,
                                     ref == 'C' ~ C))
     }
-    #bind chroms together
+    #bind contigs together
     alleles = rbindlist(chrom_list)
     #this step find the most abundant ALT base, whether A,T,C or G, assigns its count as 'altcount'
     list_ = list()

--- a/workflow/scripts/ExtractBedVCF.py
+++ b/workflow/scripts/ExtractBedVCF.py
@@ -7,9 +7,9 @@ import numpy as np
 import pandas as pd
 import allel
 
-chroms = snakemake.params['chroms']
+contigs = snakemake.params['contigs']
 
-for contig in chroms:
+for contig in contigs:
     vcf = allel.read_vcf(f"results/variantAnalysis/vcfs/annot.missense.{contig}.vcf")
         
     pos = vcf['variants/POS']

--- a/workflow/scripts/ExtractBedVCF.py
+++ b/workflow/scripts/ExtractBedVCF.py
@@ -9,15 +9,15 @@ import allel
 
 chroms = snakemake.params['chroms']
 
-for chrom in chroms:
-    vcf = allel.read_vcf(f"results/variantAnalysis/vcfs/annot.missense.{chrom}.vcf")
+for contig in chroms:
+    vcf = allel.read_vcf(f"results/variantAnalysis/vcfs/annot.missense.{contig}.vcf")
         
     pos = vcf['variants/POS']
     pos1 = pos+1
     
-    data = {'chrom':chrom, 
+    data = {'contig':contig, 
         'start':pos,
         'stop':pos1}
 
     bed = pd.DataFrame(data)
-    bed.to_csv(f"resources/regions/missense.pos.{chrom}.bed", sep="\t", header=None, index=None)
+    bed.to_csv(f"resources/regions/missense.pos.{contig}.bed", sep="\t", header=None, index=None)

--- a/workflow/scripts/GenerateFreebayesParams.R
+++ b/workflow/scripts/GenerateFreebayesParams.R
@@ -18,17 +18,17 @@ fai = fread(snakemake@input[['index']])
 fai = fai[fai$V1 %in% chroms, c(1,2)]
 
 # for each chromsome
-for (chrom in chroms){
-   #subset index to desired chrom
-   f = fai[fai$V1 == chrom]
-   #get sequence of n chunks from 0 to length of chrom
+for (contig in chroms){
+   #subset index to desired contig
+   f = fai[fai$V1 == contig]
+   #get sequence of n chunks from 0 to length of contig
    bedseq = round(seq(0, f$V2, length.out = chunks))
    
    #for each chunk
    for (i in 1:(chunks-1)){
       #write bed file, one for each chunk/interval, which will be passed as input to freebayes
-      row = c(chrom, bedseq[i], bedseq[i+1])
-      data.frame(row) %>% t() %>% fwrite(., glue("resources/regions/genome.{chrom}.region.{i}.bed"), sep="\t", col.names = FALSE)
+      row = c(contig, bedseq[i], bedseq[i+1])
+      data.frame(row) %>% t() %>% fwrite(., glue("resources/regions/genome.{contig}.region.{i}.bed"), sep="\t", col.names = FALSE)
    }
 }
 

--- a/workflow/scripts/GenerateFreebayesParams.R
+++ b/workflow/scripts/GenerateFreebayesParams.R
@@ -10,15 +10,15 @@ library(data.table)
 library(glue)
 
 # read inputs
-chroms = snakemake@params[['chroms']]
+contigs = snakemake@params[['contigs']]
 chunks = snakemake@params[['chunks']]
 fai = fread(snakemake@input[['index']])
 
-# select chroms we want, and start, end columns
-fai = fai[fai$V1 %in% chroms, c(1,2)]
+# select contigs we want, and start, end columns
+fai = fai[fai$V1 %in% contigs, c(1,2)]
 
 # for each chromsome
-for (contig in chroms){
+for (contig in contigs){
    #subset index to desired contig
    f = fai[fai$V1 == contig]
    #get sequence of n chunks from 0 to length of contig

--- a/workflow/scripts/PerGeneFstPBS.py
+++ b/workflow/scripts/PerGeneFstPBS.py
@@ -49,20 +49,20 @@ tajdbychrom={}
 gdivbychrom = {}
 dxybychrom = {}
 
-for chrom in chroms:
+for contig in chroms:
 
     # path to vcf
-    path = f"results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz"
+    path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
     # function to read in vcfs and associated SNP data
     vcf, geno, acsubpops, pos, depth, snpeff, subpops, pops = rnaseqpop.readAndFilterVcf(path=path,
-                                                               chrom=chrom, 
+                                                               contig=contig, 
                                                                samples=metadata,
                                                                numbers=numbers,
                                                                ploidy=ploidy,
                                                                qualflt=30,
                                                                missingfltprop=missingprop)
-    # subset gff to appropriate chrom
-    genes = gff[gff.seqid == chrom].sort_values('start').reset_index(drop=True)
+    # subset gff to appropriate contig
+    genes = gff[gff.seqid == contig].sort_values('start').reset_index(drop=True)
 
     ### Average Fst, pbs, tajima d for each gene
     fst_per_comp = {}
@@ -138,11 +138,11 @@ for chrom in chroms:
     gdiv_per_gene = rnaseqpop.flip_dict(gdiv_per_gene)
     dxy_per_gene = rnaseqpop.flip_dict(dxy_per_gene)
 
-    print(f"Chromosome {chrom} complete...\n")
+    print(f"Chromosome {contig} complete...\n")
     for comp1,comp2 in comparisons:
         name = comp1 + "_" + comp2
         a = np.array(list(fst_per_gene[name].values()))
-        print(f"Overall Fst (averaged across genes) for chromosome {chrom} between {name} is {np.nanmean(a)}")
+        print(f"Overall Fst (averaged across genes) for chromosome {contig} between {name} is {np.nanmean(a)}")
 
     # Make dataframe of number of snps per gene (that pass quality and missingness filters)
     ndf = pd.DataFrame.from_dict(n_dict, orient='index').reset_index(drop=False)
@@ -175,9 +175,9 @@ for chrom in chroms:
     fst_allcomparisons = reduce(my_reduce, fst_dfs.values())
     se_allcomparisons = reduce(my_reduce, se_dfs.values())
     fst_allcomparisons = reduce(my_reduce, [fst_allcomparisons, se_allcomparisons])
-    fst_allcomparisons['chrom'] = chrom
+    fst_allcomparisons['contig'] = contig
     dxy_allcomparisons = reduce(my_reduce, dxy_dfs.values())
-    dxy_allcomparisons['chrom'] = chrom
+    dxy_allcomparisons['contig'] = contig
 
     tajd_dfs = {}
     gdiv_dfs = {}
@@ -193,8 +193,8 @@ for chrom in chroms:
     # Combine tajimas d and sequence diversity for each sample
     tajdall = reduce(my_reduce, tajd_dfs.values())
     gdivall = reduce(my_reduce, gdiv_dfs.values())
-    tajdall['chrom'] = chrom
-    gdivall['chrom'] = chrom
+    tajdall['contig'] = contig
+    gdivall['contig'] = contig
 
     if pbs is True:
         # PBS store as dataframes 
@@ -205,18 +205,18 @@ for chrom in chroms:
             pbs_dfs[pbscomp] = pbs_df
 
         pbs_allcomparisons = reduce(my_reduce, pbs_dfs.values())
-        pbs_allcomparisons['chrom'] = chrom
+        pbs_allcomparisons['contig'] = contig
 
-    fstbychrom[chrom] = reduce(lambda left, right: pd.merge(left,right, on=['GeneID'],
+    fstbychrom[contig] = reduce(lambda left, right: pd.merge(left,right, on=['GeneID'],
                                                 how='inner'), [fst_allcomparisons, gene_names, ndf, posdf])
-    tajdbychrom[chrom] = reduce(lambda left, right: pd.merge(left,right, on=['GeneID'],
+    tajdbychrom[contig] = reduce(lambda left, right: pd.merge(left,right, on=['GeneID'],
                                                 how='inner'), [tajdall, gene_names, ndf,posdf])
-    gdivbychrom[chrom] = reduce(lambda left, right: pd.merge(left,right, on=['GeneID'],
+    gdivbychrom[contig] = reduce(lambda left, right: pd.merge(left,right, on=['GeneID'],
                                                 how='inner'), [gdivall, gene_names, ndf, posdf])
-    dxybychrom[chrom] = reduce(lambda left, right: pd.merge(left, right, on=['GeneID'],
+    dxybychrom[contig] = reduce(lambda left, right: pd.merge(left, right, on=['GeneID'],
                                                 how='inner'), [dxy_allcomparisons, gene_names, ndf, posdf])
     if pbs is True:
-        pbsbychrom[chrom] = reduce(lambda left,right: pd.merge(left,right,on=['GeneID'],
+        pbsbychrom[contig] = reduce(lambda left,right: pd.merge(left,right,on=['GeneID'],
                                                     how='inner'), [pbs_allcomparisons, gene_names, ndf, posdf])
     
 

--- a/workflow/scripts/PerGeneFstPBS.py
+++ b/workflow/scripts/PerGeneFstPBS.py
@@ -22,7 +22,7 @@ metadata = pd.read_csv(metadata_path, sep="\s+")
 gffpath = snakemake.input['gff']
 pbs = snakemake.params['pbs']
 pbscomps = snakemake.params['pbscomps']
-chroms = snakemake.params['chroms']
+contigs = snakemake.params['contigs']
 ploidy = snakemake.params['ploidy']
 numbers = rnaseqpop.get_numbers_dict(ploidy)
 missingprop = snakemake.params['missingprop']
@@ -49,7 +49,7 @@ tajdbychrom={}
 gdivbychrom = {}
 dxybychrom = {}
 
-for contig in chroms:
+for contig in contigs:
 
     # path to vcf
     path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"

--- a/workflow/scripts/SNPstatistics.py
+++ b/workflow/scripts/SNPstatistics.py
@@ -17,7 +17,7 @@ import rnaseqpoptools as rnaseqpop
 dataset = snakemake.params['dataset']
 metadata = pd.read_csv(snakemake.input['metadata'], sep="\t")
 metadata = metadata.sort_values(by='species')
-chroms = snakemake.params['chroms']
+contigs = snakemake.params['contigs']
 ploidy = snakemake.params['ploidy']
 numbers = rnaseqpop.get_numbers_dict(ploidy)
 qualflt = snakemake.params['qualflt']
@@ -45,7 +45,7 @@ seqdivdictchrom = {}
 thetadictchrom = {}
 coefdictchrom= {}
 
-for i, contig in enumerate(chroms):
+for i, contig in enumerate(contigs):
     
     # Read in and Filter VCF
     path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"

--- a/workflow/scripts/SNPstatistics.py
+++ b/workflow/scripts/SNPstatistics.py
@@ -45,12 +45,12 @@ seqdivdictchrom = {}
 thetadictchrom = {}
 coefdictchrom= {}
 
-for i, chrom in enumerate(chroms):
+for i, contig in enumerate(chroms):
     
     # Read in and Filter VCF
-    path = f"results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz"
+    path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
     vcf, geno, acsubpops, pos, depth, snpeff, subpops, populations = rnaseqpop.readAndFilterVcf(path=path,
-                                                           chrom=chrom,
+                                                           contig=contig,
                                                            samples=metadata,
                                                            numbers=numbers,
                                                            ploidy=ploidy,
@@ -58,24 +58,24 @@ for i, chrom in enumerate(chroms):
                                                            missingfltprop=missingprop)
     # Store total SNPs per chromosome
     # And summaries from SnpEff
-    total_snps_per_chrom[chrom] = geno.shape[0]
-    snpeffdict[chrom] = snpeff[1].value_counts(normalize=True)
+    total_snps_per_chrom[contig] = geno.shape[0]
+    snpeffdict[contig] = snpeff[1].value_counts(normalize=True)
 
     # Plot SNP density
     rnaseqpop.plot_density(pos, 
                 window_size=100000, 
-                title=f"Variant Density | {dataset} | Chromosome {chrom}", 
-                path=f"results/variantAnalysis/diversity/{dataset}_SNPdensity_{chrom}.svg")
+                title=f"Variant Density | {dataset} | Chromosome {contig}", 
+                path=f"results/variantAnalysis/diversity/{dataset}_SNPdensity_{contig}.svg")
 
     ######## SNP counts per gene ########
     # Subset GFF to appropriate chromosome
-    gff = features.query("seqid == @chrom").sort_values('start').reset_index(drop=True)
+    gff = features.query("seqid == @contig").sort_values('start').reset_index(drop=True)
     genes = gff.query("type == 'gene'")
     exons = features.query("type == 'exon'").reset_index(drop=True)
     
     ## Proportion SNPs per GFF feature
-    snpsPerGff[chrom] = rnaseqpop.getSNPGffstats(gff,  pos)
-    snpsPerGff[chrom]['chromosome'] = chrom
+    snpsPerGff[contig] = rnaseqpop.getSNPGffstats(gff,  pos)
+    snpsPerGff[contig]['chromosome'] = contig
 
     ## Calculate missing SNPs per sample, SNPs per gene etc
     snpsnotmissing = {}
@@ -104,13 +104,13 @@ for i, chrom in enumerate(chroms):
 
         snps_per_gene[gene['ID']] = dict(snps_per_sample)
 
-    snps_per_gene_allchroms[chrom] = pd.DataFrame.from_dict(rnaseqpop.flip_dict(snps_per_gene))
+    snps_per_gene_allchroms[contig] = pd.DataFrame.from_dict(rnaseqpop.flip_dict(snps_per_gene))
 
 snpsPerGff = pd.concat(snpsPerGff).reset_index().rename(columns={'level_1':'feature'})
 snpsPerGff = snpsPerGff.groupby('feature').agg({'ReferenceGenomeProportion': 'mean', 'called':'sum', 'proportion': 'mean', 'total':'sum'})
 snpsPerGff.to_csv(snakemake.output['snpsPerGenomicFeature'], sep="\t", index=True)
 
-# Total SNPs per chrom, all samples
+# Total SNPs per contig, all samples
 totalsnpsdf = pd.DataFrame.from_dict(total_snps_per_chrom, orient='index', columns=['Total_SNPs'])
 totalsnpsdf.to_csv(f"results/variantAnalysis/SNPstats/totalSNPs.tsv", sep="\t", index=True)
 

--- a/workflow/scripts/SummaryStats.py
+++ b/workflow/scripts/SummaryStats.py
@@ -29,11 +29,11 @@ pi = {}
 theta = {}
 coefdictchrom= {}
 
-for i, chrom in enumerate(chroms):
+for i, contig in enumerate(chroms):
     # Read in and Filter VCF
-    path = f"results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz"
+    path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
     vcf, geno, acsubpops, pos, depth, snpeff, subpops, populations = rnaseqpop.readAndFilterVcf(path=path,
-                                                           chrom=chrom,
+                                                           contig=contig,
                                                            samples=metadata,
                                                            numbers=numbers,
                                                            ploidy=ploidy,
@@ -42,8 +42,8 @@ for i, chrom in enumerate(chroms):
 
 
     # Genome-wide statistics (Pi, Wattersons Theta, inbreeding coefficient)
-    pi[chrom] = rnaseqpop.windowedDiversity(geno=geno, pos=pos, subpops=subpops, statistic='pi', window_size=20_000)
-    theta[chrom] = rnaseqpop.windowedDiversity(geno=geno, pos=pos, subpops=subpops, statistic='theta', window_size=20_000)    
+    pi[contig] = rnaseqpop.windowedDiversity(geno=geno, pos=pos, subpops=subpops, statistic='pi', window_size=20_000)
+    theta[contig] = rnaseqpop.windowedDiversity(geno=geno, pos=pos, subpops=subpops, statistic='theta', window_size=20_000)    
     
     coefdict= {}
     allcoef = defaultdict(list)
@@ -56,8 +56,8 @@ for i, chrom in enumerate(chroms):
             coefdict[pop] = np.mean(coef)
             allcoef[pop].append(np.array(coef))
 
-        if ploidy > 1: print(f"{pop} | {chrom} | Inbreeding Coef =", np.mean(coef), "\n")
-    if ploidy > 1: coefdictchrom[chrom] = dict(coefdict)
+        if ploidy > 1: print(f"{pop} | {contig} | Inbreeding Coef =", np.mean(coef), "\n")
+    if ploidy > 1: coefdictchrom[contig] = dict(coefdict)
 
 # Concat contigs, get CIs for Pi and Theta and save to file
 pi_df = rnaseqpop.diversity_ci_table(div_dict=pi, statistic='pi').to_csv("results/variantAnalysis/diversity/SequenceDiversity.tsv", sep="\t", index=True)

--- a/workflow/scripts/SummaryStats.py
+++ b/workflow/scripts/SummaryStats.py
@@ -17,7 +17,7 @@ import rnaseqpoptools as rnaseqpop
 dataset = snakemake.params['dataset']
 metadata = pd.read_csv(snakemake.input['metadata'], sep="\t")
 metadata = metadata.sort_values(by='species')
-chroms = snakemake.params['chroms']
+contigs = snakemake.params['contigs']
 ploidy = snakemake.params['ploidy']
 numbers = rnaseqpop.get_numbers_dict(ploidy)
 qualflt = snakemake.params['qualflt']
@@ -29,7 +29,7 @@ pi = {}
 theta = {}
 coefdictchrom= {}
 
-for i, contig in enumerate(chroms):
+for i, contig in enumerate(contigs):
     # Read in and Filter VCF
     path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
     vcf, geno, acsubpops, pos, depth, snpeff, subpops, populations = rnaseqpop.readAndFilterVcf(path=path,

--- a/workflow/scripts/VariantsOfInterestAlleleBalance.R
+++ b/workflow/scripts/VariantsOfInterestAlleleBalance.R
@@ -75,14 +75,14 @@ for (m in mutation_data$Name){
   # average across replicates
   if (!base2 %in% c("", NA)){
     mean_alleles = mean_alleles %>% 
-      group_by(chrom, pos, ref, mutation, treatment, !!sym(propstring), lowerCI, upperCI, !!sym(propstring2), lowerCI_2, upperCI_2) %>% 
+      group_by(contig, pos, ref, mutation, treatment, !!sym(propstring), lowerCI, upperCI, !!sym(propstring2), lowerCI_2, upperCI_2) %>% 
       summarise_at(.vars = c("cov","A","C","G","T"), .funs = c(mean="mean"), na.rm = TRUE) %>% 
-      select(chrom, pos, ref, mutation, treatment, cov_mean, A_mean, C_mean, G_mean, T_mean, lowerCI, upperCI, !!propstring, !!propstring2, lowerCI_2, upperCI_2)
+      select(contig, pos, ref, mutation, treatment, cov_mean, A_mean, C_mean, G_mean, T_mean, lowerCI, upperCI, !!propstring, !!propstring2, lowerCI_2, upperCI_2)
   } else {
     mean_alleles = mean_alleles %>% 
-      group_by(chrom, pos, ref, mutation, treatment, !!sym(propstring), lowerCI, upperCI) %>% 
+      group_by(contig, pos, ref, mutation, treatment, !!sym(propstring), lowerCI, upperCI) %>% 
       summarise_at(.vars = c("cov","A","C","G","T"), .funs = c(mean="mean"), na.rm = TRUE) %>% 
-      select(chrom,pos, ref, mutation, treatment, cov_mean, A_mean, C_mean, G_mean, T_mean, lowerCI, upperCI, !!propstring)
+      select(contig,pos, ref, mutation, treatment, cov_mean, A_mean, C_mean, G_mean, T_mean, lowerCI, upperCI, !!propstring)
   }
   
   #write to file, reorder mean_kdr_alleles

--- a/workflow/scripts/VariantsOfInterestPlot.py
+++ b/workflow/scripts/VariantsOfInterestPlot.py
@@ -16,10 +16,10 @@ voiPath = snakemake.input['VariantsOfInterest']
 ## Read VOI data
 muts = pd.read_csv(voiPath, sep="\t")
 
-## separate chrom and pos data and sort 
-muts['chrom'] = muts['Location'].str.split(":").str.get(0)
+## separate contig and pos data and sort 
+muts['contig'] = muts['Location'].str.split(":").str.get(0)
 muts['pos'] = muts['Location'].str.split(":").str.get(1).str.split("-").str.get(0)
-muts = muts.sort_values(['chrom', 'pos'])
+muts = muts.sort_values(['contig', 'pos'])
 
 
 ## Run for all samples

--- a/workflow/scripts/WindowedFstPBS.py
+++ b/workflow/scripts/WindowedFstPBS.py
@@ -33,11 +33,11 @@ comparisons = comparisons.contrast.str.split("_", expand=True)
 comparisons.columns = ['sus', 'res']
 comparisons = [list(row) for i,row in comparisons.iterrows()]
 
-for i, chrom in enumerate(chroms):
+for i, contig in enumerate(chroms):
 
-    path = f"results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz"
+    path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
     vcf, geno, acsubpops, pos, depth, snpeff, subpops, populations = rnaseqpop.readAndFilterVcf(path=path,
-                                                           chrom=chrom,
+                                                           contig=contig,
                                                            samples=metadata,
                                                            numbers=numbers,
                                                            ploidy=ploidy,
@@ -64,7 +64,7 @@ for i, chrom in enumerate(chroms):
                         midpoints=midpoint,
                         colour='dodgerblue',
                         prefix="results/variantAnalysis/selection/fst", 
-                        chrom=chrom, 
+                        contig=contig, 
                         ylim=1, 
                         save=True)
 
@@ -91,6 +91,6 @@ for i, chrom in enumerate(chroms):
                             midpoints=midpoint, 
                             colour='dodgerblue',
                             prefix="results/variantAnalysis/selection/pbs",
-                            chrom=chrom, 
+                            contig=contig, 
                             ylim=0.5, 
                             save=True)

--- a/workflow/scripts/WindowedFstPBS.py
+++ b/workflow/scripts/WindowedFstPBS.py
@@ -14,7 +14,7 @@ import rnaseqpoptools as rnaseqpop
 dataset = snakemake.params['dataset']
 metadata = pd.read_csv(snakemake.input['metadata'], sep="\t")
 metadata = metadata.sort_values(by='species')
-chroms = snakemake.params['chroms']
+contigs = snakemake.params['contigs']
 ploidy = snakemake.params['ploidy']
 numbers = rnaseqpop.get_numbers_dict(ploidy)
 pbs = snakemake.params['pbs']
@@ -33,7 +33,7 @@ comparisons = comparisons.contrast.str.split("_", expand=True)
 comparisons.columns = ['sus', 'res']
 comparisons = [list(row) for i,row in comparisons.iterrows()]
 
-for i, contig in enumerate(chroms):
+for i, contig in enumerate(contigs):
 
     path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
     vcf, geno, acsubpops, pos, depth, snpeff, subpops, populations = rnaseqpop.readAndFilterVcf(path=path,

--- a/workflow/scripts/checkInputs.py
+++ b/workflow/scripts/checkInputs.py
@@ -22,7 +22,7 @@ import allel
 metadata = pd.read_csv(snakemake.params['metadata'], sep="\t")
 ref = snakemake.input['ref']
 gffpath = snakemake.params['gffpath']
-chroms = snakemake.params['chroms']
+contigs = snakemake.params['contigs']
 autofastq = snakemake.params['fastq']
 sweeps = snakemake.params['sweeps']
 signalpath = "resources/signals.csv"
@@ -34,7 +34,7 @@ refchroms = []
 for line in file:
     if re.search(">", line):
         refchroms.append(line.split()[0].replace(">", ""))
-assert (np.isin(chroms, refchroms)).all(), f"Not all chromosome names specified in config.yaml are found in the reference fasta file ({ref})"
+assert (np.isin(contigs, refchroms)).all(), f"Not all chromosome names specified in config.yaml are found in the reference fasta file ({ref})"
 
 
 # Check that the contrasts specified in config.yaml are all in the treatment column
@@ -64,4 +64,4 @@ assert (gene_names.columns.isin(colnames)).all(), f"Column names of gene_names.t
 
 # Check that the chromosomes are present in the gff file 
 gff = allel.gff3_to_dataframe(gffpath)
-assert np.isin(chroms, gff.seqid).all(), f"All provided chromosome names ({chroms}) are not present in the reference GFF file"
+assert np.isin(contigs, gff.seqid).all(), f"All provided chromosome names ({contigs}) are not present in the reference GFF file"

--- a/workflow/scripts/geneScan.py
+++ b/workflow/scripts/geneScan.py
@@ -14,10 +14,10 @@ ploidy = int(sys.argv[5])
 
 metadata = pd.read_csv(metadatapath, sep="\t")
 gff = allel.gff3_to_dataframe(gffpath, attributes=['Parent', 'ID'])
-chrom, start, end = gff.query("ID == @geneID")[['seqid', 'start', 'end']].values[0]
+contig, start, end = gff.query("ID == @geneID")[['seqid', 'start', 'end']].values[0]
 
 numbers = rnaseqpop.get_numbers_dict(ploidy)
-vcf, geno, ac_subpops, pos, depth, snpeff, subpops, samplenames = rnaseqpop.readAndFilterVcf(vcfpath, chrom, metadata, numbers, ploidy, qualflt=0, missingfltprop=0, verbose=False)
+vcf, geno, ac_subpops, pos, depth, snpeff, subpops, samplenames = rnaseqpop.readAndFilterVcf(vcfpath, contig, metadata, numbers, ploidy, qualflt=0, missingfltprop=0, verbose=False)
 ann = allel.read_vcf(vcfpath,  fields=['ANN'], numbers={'ANN':1})
 
 

--- a/workflow/scripts/pca.py
+++ b/workflow/scripts/pca.py
@@ -18,14 +18,14 @@ from adjustText import adjust_text
 dataset = snakemake.params['dataset']
 metadata = pd.read_csv(snakemake.input['metadata'], sep="\t")
 metadata = metadata.sort_values(by='species')
-chroms = snakemake.params['chroms']
+contigs = snakemake.params['contigs']
 ploidy = snakemake.params['ploidy']
 numbers = rnaseqpop.get_numbers_dict(ploidy)
 qualflt = snakemake.params['qualflt']
 missingprop = snakemake.params['missingprop']
 
 
-for i, contig in enumerate(chroms):
+for i, contig in enumerate(contigs):
     
     # Read in and Filter VCF
     path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"

--- a/workflow/scripts/pca.py
+++ b/workflow/scripts/pca.py
@@ -25,12 +25,12 @@ qualflt = snakemake.params['qualflt']
 missingprop = snakemake.params['missingprop']
 
 
-for i, chrom in enumerate(chroms):
+for i, contig in enumerate(chroms):
     
     # Read in and Filter VCF
-    path = f"results/variantAnalysis/vcfs/{dataset}.{chrom}.vcf.gz"
+    path = f"results/variantAnalysis/vcfs/{dataset}.{contig}.vcf.gz"
     vcf, geno, acsubpops, pos, depth, snpeff, subpops, populations = rnaseqpop.readAndFilterVcf(path=path,
-                                                           chrom=chrom,
+                                                           contig=contig,
                                                            samples=metadata,
                                                            numbers=numbers,
                                                            ploidy=ploidy,
@@ -52,5 +52,5 @@ for i, chrom in enumerate(chroms):
     pop_colours = rnaseqpop.get_colour_dict(treatment_indices['name'], "viridis")
     
     # Run PCA function defined in tools.py
-    print(f"Performing PCA on {dataset} chromosome {chrom}")
-    rnaseqpop.pca(geno, chrom, ploidy, dataset, populations, metadata, pop_colours, prune=True, scaler=None)
+    print(f"Performing PCA on {dataset} chromosome {contig}")
+    rnaseqpop.pca(geno, contig, ploidy, dataset, populations, metadata, pop_colours, prune=True, scaler=None)


### PR DESCRIPTION
Removing the use of a separate table to specify the fastq paths, and instead users can have an fq1 and fq2 column in the metadata instead, which simplifies things. 

Users may still use automatic fastq paths by using resources/reads and naming fastqs as - {sampleID}_1.fastq.gz , {sampleID}_2.fastq.gz
