### PR TITLE
freebayes add parameter: min-alternate-fraction 0.05

### DIFF
--- a/workflow/rules/hisat2-freebayes.smk
+++ b/workflow/rules/hisat2-freebayes.smk
@@ -96,7 +96,7 @@ rule VariantCallingFreebayes:
         "../envs/variants.yaml"
     threads: 1
     shell:
-        "freebayes -f {input.ref} -t {input.regions} --ploidy {params.ploidy} --populations {input.pops} --pooled-discrete --use-best-n-alleles 5 -L {input.samples} > {output} 2> {log}"
+        "freebayes -f {input.ref} -t {input.regions} --ploidy {params.ploidy} --populations {input.pops} --pooled-discrete --use-best-n-alleles 5 --min-alternate-fraction 0.05 -L {input.samples} > {output} 2> {log}"
 
 chunks = np.arange(1, config["VariantAnalysis"]["chunks"])
 


### PR DESCRIPTION
Add new freebayes parameter which was by default set to 0.20. 

In theory this means that previously, if 10% of the reads in a sample are alternate, it will not be called as a SNP. This is fine for diploid samples, but not for high ploidy, which is how we approach pooled samples. 